### PR TITLE
Ghc 7.10

### DIFF
--- a/concurrent-supply.cabal
+++ b/concurrent-supply.cabal
@@ -36,7 +36,7 @@ library
   build-depends:
     base     >= 4 && < 5,
     hashable >= 1.1 && < 1.3,
-    ghc-prim >= 0.2 && < 0.4
+    ghc-prim >= 0.2 && < 0.5
 
 test-suite properties
   type: exitcode-stdio-1.0

--- a/concurrent-supply.cabal
+++ b/concurrent-supply.cabal
@@ -1,6 +1,6 @@
 name:          concurrent-supply
 category:      Concurrency, Parallelism
-version:       0.1.7
+version:       0.1.7.1
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE

--- a/src/Control/Concurrent/Supply.hs
+++ b/src/Control/Concurrent/Supply.hs
@@ -41,8 +41,10 @@ module Control.Concurrent.Supply
 
 import Data.Hashable
 import Data.IORef
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 710
 import Data.Functor ((<$>))
 import Data.Monoid
+#endif
 import GHC.IO (unsafeDupablePerformIO, unsafePerformIO)
 import GHC.Types (Int(..))
 import GHC.Prim (Int#)


### PR DESCRIPTION
`ghc-prim` on the ghc-7.10 branch has been updated to version 0.4. With this patch we have a warning-free compilation on `ghc-7.10.0.20150323`.