### PR TITLE
add monadic api

### DIFF
--- a/concurrent-supply.cabal
+++ b/concurrent-supply.cabal
@@ -36,6 +36,7 @@ library
   build-depends:
     base     >= 4 && < 5,
     hashable >= 1.1 && < 1.3,
+    transformers >=0.3 && <0.5,
     ghc-prim >= 0.2 && < 0.5
 
 test-suite properties


### PR DESCRIPTION
This patch adds a monadic API, essentially a newtype wrapper around `StateT Supply`, to provide a nicer interface.
